### PR TITLE
Fix missing import bug

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -1,4 +1,5 @@
 import os
+import math
 os.mkdir("NavData")
 os.mkdir("NavData/fix")
 effdate = input("NASR effective date >>> ")


### PR DESCRIPTION
parser.py uses `math.log` without first importing the math library. This causes runtime failures on Arch Linux. Simply importing the library seems to fix the issue, again on Arch Linux.